### PR TITLE
Restart slavePoller in case scraping failed

### DIFF
--- a/slave_poller.go
+++ b/slave_poller.go
@@ -101,7 +101,7 @@ func retrieveStats(c *http.Client, stats *[]MonitoredTask, url string) error {
 }
 
 // Periodically queries a Mesos slave and updates statistics of each running task
-func slavePoller(c *http.Client, conf *Config, frameworkRegistry *frameworkRegistry, slave Slave) {
+func slavePoller(c *http.Client, conf *Config, frameworkRegistry *frameworkRegistry, slave Slave, erroredSlaves *map[string]struct{}) {
 	var knownTasks map[string]taskMetric
 	var monitoredTasks []MonitoredTask
 
@@ -157,6 +157,8 @@ func slavePoller(c *http.Client, conf *Config, frameworkRegistry *frameworkRegis
 			prometheus.Unregister(memRssGauge)
 
 			log.Errorf("Error retrieving stats from slave '%s' - Stopping goroutine", slave.Pid)
+
+			(*erroredSlaves)[slave.Pid] = struct{}{}
 			return
 		}
 


### PR DESCRIPTION
In case `retrieveStats` fails for a slave for a reason other than being down, that particular slave is never being scraped again because it remains in `knownSlaves` and also in `availableSlaves`. This adds a possibility for the `slavePoller` to mark the scraper process of its `slave.Pid` as errored. Upon revisiting this slave, the routine will then be started again by the `masterPoller`.
